### PR TITLE
Adding plugins and proxy details while installing jenkins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,13 +10,19 @@ jenkins_home: /var/lib/jenkins
 jenkins_hostname: localhost
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
-jenkins_plugins: []
+jenkins_plugins: 
+    - workflow-aggregator
+    - workflow-api
+    - workflow-step-api
+    - pipeline-build-step
+    - workflow-basic-steps
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin
 jenkins_admin_password_file: ""
+jenkins_proxy_conf_file: "{{ jenkins_home }}/proxy.xml"
 
 jenkins_init_changes:
   - option: "JENKINS_ARGS"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,5 +54,9 @@
     path: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
     state: absent
 
+
+# Include proxy server settings file
+- include: proxy.yml
+
 # Update Jenkins and install configured plugins.
 - include: plugins.yml

--- a/tasks/proxy.yml
+++ b/tasks/proxy.yml
@@ -1,0 +1,12 @@
+---
+# Jenkins proxy settings addition
+# 
+- name: "update Jenkins proxy setting"
+  template:
+    src: "proxy.xml.j2"
+    dest: "{{ jenkins_proxy_conf_file }}"
+    owner: jenkins
+    group: jenkins
+    mode: 0755
+  register: proxy_config
+  notify: restart jenkins

--- a/templates/proxy.xml.j2
+++ b/templates/proxy.xml.j2
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<proxy>
+  <name>{{ proxy_host }}</name>
+  <port>{{ proxy_port }}</port>
+  <testUrl>http://updates.jenkins-ci.org/update-center.json</testUrl>
+</proxy>


### PR DESCRIPTION
We have tested jenkins plugins part, but not proxy part.. Also need to modify hzaansible to send proxy_host and proxy_port to setup proxy for jenkins